### PR TITLE
Fix bugs in PaymentProcessor and add transaction status validation

### DIFF
--- a/src/project_to_modify/transaction_service.py
+++ b/src/project_to_modify/transaction_service.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 from dataclasses import dataclass
 from datetime import datetime
 
+
 @dataclass
 class Transaction:
     id: str
@@ -49,6 +50,9 @@ class PaymentProcessor:
             return "ERROR: Transaction not found"
         
         transaction = self.transactions[transaction_id]
+        
+        if transaction.status != "PENDING":
+            return "ERROR: Transaction already processed"
         
         if transaction.amount == 0:
             return "ERROR: Cannot process refund for zero amount"

--- a/tests/test_transaction_service.py
+++ b/tests/test_transaction_service.py
@@ -45,3 +45,25 @@ def test_process_refund_non_existent_transaction_zero_amount():
     processor = PaymentProcessor()
     result = processor.process_refund("non_existent", 0)
     assert result == "ERROR: Transaction not found"
+
+
+def test_process_refund_already_processed():
+    processor = PaymentProcessor()
+    processor.add_transaction("tx1", 100)
+    processor.process_refund("tx1", 50)
+    result = processor.process_refund("tx1", 50)
+    assert result == "ERROR: Transaction already processed"
+
+
+def test_process_refund_success():
+    processor = PaymentProcessor()
+    processor.add_transaction("tx1", 100)
+    result = processor.process_refund("tx1", 50)
+    assert result == "SUCCESS: Refund ratio 0.50 processed"
+
+
+def test_process_refund_full_amount():
+    processor = PaymentProcessor()
+    processor.add_transaction("tx1", 100)
+    result = processor.process_refund("tx1", 100)
+    assert result == "SUCCESS: Refund ratio 1.00 processed"


### PR DESCRIPTION
Fixed bugs in PaymentProcessor:
1. Added validation for transaction status in process_refund - now checks if transaction is still PENDING
2. Added new tests for transaction status validation
3. All existing tests pass successfully

The changes ensure that refunds can only be processed for transactions that haven't been processed yet.

Closes #1